### PR TITLE
Не запускаем конфигураторы, не перечисленные в приоритетах

### DIFF
--- a/_Src/Container/Implementation/ConfiguratorRunner.cs
+++ b/_Src/Container/Implementation/ConfiguratorRunner.cs
@@ -45,6 +45,7 @@ namespace SimpleContainer.Implementation
 						.GroupBy(configurator => priorities == null
 							? 0
 							: GetLeafInterfaces(configurator).Max(x => Array.IndexOf(priorities, x.GetDefinition())))
+						.Where(x => x.Key >= 0)
 						.OrderByDescending(x => x.Key)
 						.DefaultIfEmpty(Enumerable.Empty<IServiceConfigurator<T>>())
 						.First();

--- a/_Src/Tests/ContainerConfigurationTest.cs
+++ b/_Src/Tests/ContainerConfigurationTest.cs
@@ -787,5 +787,34 @@ namespace SimpleContainer.Tests
 				Assert.That(container.GetImplementationsOf<IService>(), Is.EqualTo(new[] {typeof (ImplTwo)}));
 			}
 		}
+
+		public class ConfiguratorTypeNotIncludedInPriorities_DoNotApply : SimpleContainerTestBase
+		{
+			public interface IExcludedConfigurator<T> : IServiceConfigurator<T>
+			{
+			}
+
+			public class Service
+			{
+			}
+
+			public class ExcludedConfiguratorImplementation : IExcludedConfigurator<Service>
+			{
+				public void Configure(ConfigurationContext context, ServiceConfigurationBuilder<Service> builder)
+				{
+					builder.DontUse();
+				}
+			}
+
+			[Test]
+			public void Test()
+			{
+				var container = Factory()
+					.WithPriorities(typeof(IServiceConfigurator<>))
+					.Build();
+
+				Assert.That(container.GetImplementationsOf<Service>(), Is.Not.Empty);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Если при создании контейнера интерфейс конфигуратора не перечислен в приоритетах - не запускать его. Если WithPriorities не звали - запустить все IServiceConfigurator<>

Сценарий:
Есть сборка с тестовой инфраструктурой, в которой есть конфигуратор, биндящий на in-memory реализации. Эти сборки референсятся из функциональных тестов, где реализации должны быть настоящие. Не хотим плодить сборки, не хотим писать конфигураторы в функциональных тестах только для того, чтобы перебить in-memory