### PR TITLE
T вместо object в AbstractServiceConfigurationBuilder<T>

### DIFF
--- a/_Src/Container/Configuration/AbstractServiceConfigurationBuilder.cs
+++ b/_Src/Container/Configuration/AbstractServiceConfigurationBuilder.cs
@@ -75,7 +75,7 @@ namespace SimpleContainer.Configuration
 			return Self;
 		}
 
-		public TSelf Bind(object value, bool containerOwnsInstance = true)
+		public TSelf Bind(TService value, bool containerOwnsInstance = true)
 		{
 			GetServiceBuilder().Bind(typeof (TService), value, containerOwnsInstance);
 			return Self;


### PR DESCRIPTION
Не разваливаемся в рантайме если биндим для TService конкретный экземпляр и нечаянно передали какой-то левый объект.