### PR TITLE
Change target framework to 4.5, allow non-nested ctor delegates

### DIFF
--- a/_Src/Container/Container.csproj
+++ b/_Src/Container/Container.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SimpleContainer</RootNamespace>
     <AssemblyName>SimpleContainer</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/_Src/Tests/Factories/CtorDelegatesTest.cs
+++ b/_Src/Tests/Factories/CtorDelegatesTest.cs
@@ -349,7 +349,7 @@ namespace SimpleContainer.Tests.Factories
 			{
 				var container = Container();
 				var exception = Assert.Throws<SimpleContainerException>(() => container.Get<A.Ctor>());
-				Assert.That(exception.Message, Is.EqualTo("can't create delegate [A.Ctor]\r\n\r\n!A.Ctor <---------------"));
+				Assert.That(exception.Message, Is.EqualTo("can't create delegate [A.Ctor]. return type must match declaring\r\n\r\n!A.Ctor <---------------"));
 			}
 		}
 
@@ -366,7 +366,7 @@ namespace SimpleContainer.Tests.Factories
 				var container = Container();
 				var ctorType = typeof (A).GetNestedTypes(BindingFlags.NonPublic).Single(x => x.Name == "Ctor");
 				var exception = Assert.Throws<SimpleContainerException>(() => container.Get(ctorType));
-				Assert.That(exception.Message, Is.EqualTo("can't create delegate [A.Ctor]\r\n\r\n!A.Ctor <---------------"));
+				Assert.That(exception.Message, Is.EqualTo("can't create delegate [A.Ctor]. must be nested public\r\n\r\n!A.Ctor <---------------"));
 			}
 		}
 
@@ -399,5 +399,28 @@ namespace SimpleContainer.Tests.Factories
 				Assert.That(instance.name2.Type, Is.EqualTo(typeof (A)));
 			}
 		}
+
+		public class SkipNonNestedDelegate : CtorDelegatesTest
+		{
+			public class Service
+			{
+				public int Value { get; set; }
+
+				public Service(int value)
+				{
+					Value = value;
+				}
+			}
+
+			[Test]
+			public void Test()
+			{
+				var container = Container();
+				var exception = Assert.Throws<SimpleContainerException>(() => container.Get<ServiceCtor>());
+				Assert.That(exception.Message, Is.EqualTo("can't create delegate [ServiceCtor]. must be nested public\r\n\r\n!ServiceCtor <---------------"));
+			}
+		}
 	}
+
+	public delegate CtorDelegatesTest.SkipNonNestedDelegate.Service ServiceCtor(int value);
 }

--- a/_Src/Tests/Tests.csproj
+++ b/_Src/Tests/Tests.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SimpleContainer.Tests</RootNamespace>
     <AssemblyName>SimpleContainer.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Change target framework to 4.5
потому что ты не используешь 4.5.1 а нам неохота обновлять Эльбу на 4.5.1 и проверять что, не знаю, дурацкий ASP.NET не сломали в минорной версии.

allow non-nested ctor delegates
потому что у кого-то плохая память и он второй раз пишет Ctor рядом, а не внутри класса а потом удивляется.=(