### PR TITLE
Small bug

### DIFF
--- a/_Src/Container/Interface/SimpleContainerException.cs
+++ b/_Src/Container/Interface/SimpleContainerException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace SimpleContainer.Interface
 {
@@ -11,6 +12,10 @@ namespace SimpleContainer.Interface
 		}
 
 		public SimpleContainerException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+
+		protected SimpleContainerException(SerializationInfo info, StreamingContext context) : base(info, context)
 		{
 		}
 	}

--- a/_Src/Tests/Factories/FactoriesBasicTest.cs
+++ b/_Src/Tests/Factories/FactoriesBasicTest.cs
@@ -264,36 +264,6 @@ namespace SimpleContainer.Tests.Factories
 			}
 		}
 
-		public class CorrectErrorMessageForCyclesWithContracts : FactoriesBasicTest
-		{
-			public class A
-			{
-				public readonly B b;
-
-				public A([TestContract("x")] B b)
-				{
-					this.b = b;
-				}
-			}
-
-			public class B
-			{
-				public B(IContainer container)
-				{
-					container.Get<A>();
-				}
-			}
-
-			[Test]
-			public void Test()
-			{
-				var container = Container();
-				var exception = Assert.Throws<SimpleContainerException>(() => container.Get<A>());
-				Assert.That(exception.Message, Is.EqualTo("cyclic dependency for service [A], stack\r\n\tA\r\n\tB[x]\r\n\tA\r\n\r\n!A\r\n\t!B\r\n\t\tIContainer\r\n\t\t!() => A"));
-				Assert.That(exception.InnerException, Is.Null);
-			}
-		}
-
 		public class DetectIndirectCycles : FactoriesBasicTest
 		{
 			public class A


### PR DESCRIPTION
Падали с CyclicDependency хотя на самом деле циклической зависимости нет. 
Баг - в проверке на CyclicDependency не учитывались контракты на стеке.
Тест SameInterfaceInContractNotACyclicDependency 

После того как пофиксили сломался тест CorrectErrorMessageForCyclesWithContracts тк. вместо CyclicDependency стал падать с ContractAlreadyDeclared. Долго смотрели, не могли понять что он проверяет - в итоге тест снесли. Если не правы - верни его на место, плиз.=)
