### PR TITLE
.net core rtm support through portability layer

### DIFF
--- a/_Src/Container/Configuration/ServiceConfiguration.cs
+++ b/_Src/Container/Configuration/ServiceConfiguration.cs
@@ -88,7 +88,7 @@ namespace SimpleContainer.Configuration
 
 			public void Bind(Type interfaceType, Type implementationType, bool clearOld)
 			{
-				if (!interfaceType.IsGenericTypeDefinition && !implementationType.IsGenericTypeDefinition &&
+				if (!interfaceType.IsGenericTypeDefinition() && !implementationType.IsGenericTypeDefinition() &&
 				    !interfaceType.IsAssignableFrom(implementationType))
 					throw new SimpleContainerException(string.Format("[{0}] is not assignable from [{1}]",
 						interfaceType.FormatName(), implementationType.FormatName()));
@@ -109,7 +109,7 @@ namespace SimpleContainer.Configuration
 
 			public void Bind(Type interfaceType, object value, bool containerOwnsInstance)
 			{
-				if (interfaceType.ContainsGenericParameters)
+				if (interfaceType.ContainsGenericParameters())
 					throw new SimpleContainerException(string.Format("can't bind value for generic definition [{0}]",
 						interfaceType.FormatName()));
 				if (value != null && interfaceType.IsInstanceOfType(value) == false)

--- a/_Src/Container/ContainerFactory.cs
+++ b/_Src/Container/ContainerFactory.cs
@@ -136,7 +136,7 @@ namespace SimpleContainer
 				{
 					try
 					{
-						return AssemblyName.GetAssemblyName(s);
+						return Portability.GetAssemblyName(s);
 					}
 					catch (BadImageFormatException)
 					{
@@ -169,7 +169,7 @@ namespace SimpleContainer
 			if (typesContext == null)
 			{
 				var targetTypes = types()
-					.Concat(Assembly.GetExecutingAssembly().GetTypes())
+					.Concat(Portability.GetSimpleContainerAssembly().GetTypes())
 					.Where(x => !x.Name.StartsWith("<>", StringComparison.OrdinalIgnoreCase))
 					.Distinct()
 					.ToArray();

--- a/_Src/Container/Helpers/AssemblyHelpers.cs
+++ b/_Src/Container/Helpers/AssemblyHelpers.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Reflection;
+using System.Runtime;
+using System.Runtime.InteropServices;
 using SimpleContainer.Interface;
 
 namespace SimpleContainer.Helpers
@@ -14,10 +16,16 @@ namespace SimpleContainer.Helpers
 			}
 			catch (BadImageFormatException e)
 			{
+#if NETCORE1
+				const string messageFormat = "bad assembly image, assembly name [{0}], process is [{1}]";
+				throw new SimpleContainerException(string.Format(messageFormat,
+					e.FileName, RuntimeInformation.ProcessArchitecture), e);
+#else
 				const string messageFormat = "bad assembly image, assembly name [{0}], " +
 				                             "process is [{1}],\r\nFusionLog\r\n{2}";
 				throw new SimpleContainerException(string.Format(messageFormat,
-					e.FileName, Environment.Is64BitProcess ? "x64" : "x86", e.FusionLog), e);
+					e.FileName, RuntimeInformation.ProcessArchitecture, e.FusionLog), e);
+#endif
 			}
 		}
 	}

--- a/_Src/Container/Helpers/InternalHelpers.cs
+++ b/_Src/Container/Helpers/InternalHelpers.cs
@@ -30,6 +30,13 @@ namespace SimpleContainer.Helpers
 			return new T().ContractName;
 		}
 
+#if NETCORE1
+		public static string[] ParseContracts(Type provider)
+		{
+			return ParseContracts(provider.GetTypeInfo());
+		}
+#endif
+
 		public static string[] ParseContracts(ICustomAttributeProvider provider)
 		{
 			var attributes = provider.GetCustomAttributes<RequireContractAttribute>();

--- a/_Src/Container/Helpers/ReflectionEmit/Caster.cs
+++ b/_Src/Container/Helpers/ReflectionEmit/Caster.cs
@@ -26,7 +26,7 @@ namespace SimpleContainer.Helpers.ReflectionEmit
 			if (!outputType.IsAssignableFrom(memberType))
 				throw new TypeMismatchException(outputType, memberType);
 
-			if (memberType.IsValueType && !outputType.IsValueType)
+			if (memberType.IsValueType() && !outputType.IsValueType())
 				EmitValueTypeCast(ilGenerator);
 
 			if (outputType.IsNullableOf(memberType))

--- a/_Src/Container/Helpers/ReflectionEmit/MemberAccessorFactory.cs
+++ b/_Src/Container/Helpers/ReflectionEmit/MemberAccessorFactory.cs
@@ -33,7 +33,7 @@ namespace SimpleContainer.Helpers.ReflectionEmit
 				return;
 			ilGenerator.Emit(OpCodes.Ldarg_0);
 			var declaringType = member.DeclaringType;
-			if (!declaringType.IsValueType)
+			if (!declaringType.IsValueType())
 				return;
 			ilGenerator.Emit(OpCodes.Unbox_Any, declaringType);
 			ilGenerator.DeclareLocal(declaringType);

--- a/_Src/Container/Implementation/ContainerContext.cs
+++ b/_Src/Container/Implementation/ContainerContext.cs
@@ -18,7 +18,7 @@ namespace SimpleContainer.Implementation
 		public Type[] AllTypes()
 		{
 			return allTypes ??
-			       (allTypes = typesList.Types.Where(x => x.Assembly != typeof (SimpleContainer).Assembly).ToArray());
+			       (allTypes = typesList.Types.Where(x => x.Assembly() != typeof (SimpleContainer).Assembly()).ToArray());
 		}
 
 		private Type[] allTypes;

--- a/_Src/Container/Implementation/CtorFactoryCreator.cs
+++ b/_Src/Container/Implementation/CtorFactoryCreator.cs
@@ -15,7 +15,7 @@ namespace SimpleContainer.Implementation
 			if (!builder.Type.IsDelegate() || builder.Type.FullName.StartsWith("System.Func`"))
 				return false;
 			var invokeMethod = builder.Type.GetMethod("Invoke");
-			if (!builder.Type.IsNestedPublic)
+			if (!builder.Type.IsNestedPublic())
 			{
 				builder.SetError(string.Format("can't create delegate [{0}]. must be nested public", builder.Type.FormatName()));
 				return true;
@@ -97,7 +97,7 @@ namespace SimpleContainer.Implementation
 					il.Emit(OpCodes.Ldarg_0);
 					il.EmitLdInt32(serviceIndex);
 					il.Emit(OpCodes.Ldelem_Ref);
-					il.Emit(p.ParameterType.IsValueType ? OpCodes.Unbox_Any : OpCodes.Castclass, p.ParameterType);
+					il.Emit(p.ParameterType.IsValueType() ? OpCodes.Unbox_Any : OpCodes.Castclass, p.ParameterType);
 				}
 			}
 			if (delegateParameterNameToIndexMap.Count > 0)

--- a/_Src/Container/Implementation/FactoryCreator.cs
+++ b/_Src/Container/Implementation/FactoryCreator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Emit;
 using SimpleContainer.Annotations;
 using SimpleContainer.Helpers;
 using SimpleContainer.Interface;
@@ -20,13 +21,13 @@ namespace SimpleContainer.Implementation
 		private static readonly Func<SignatureDelegateKey, Delegate> createCaster = delegate(SignatureDelegateKey key)
 		{
 			var delegateType = typeof (Func<Func<Type, object, object>, object>);
-			return Delegate.CreateDelegate(delegateType, key.signature.MakeGenericMethod(key.resultType));
+			return key.signature.MakeGenericMethod(key.resultType).CreateDelegate(delegateType);
 		};
 
 		public static object TryCreate(ContainerService.Builder builder)
 		{
 			var funcType = builder.Type;
-			if (!funcType.IsGenericType || !funcType.IsDelegate())
+			if (!funcType.IsGenericType() || !funcType.IsDelegate())
 				return null;
 			Type resultType;
 			var signature = FindSignature(funcType, out resultType);

--- a/_Src/Container/Implementation/GenericsAutoCloser.cs
+++ b/_Src/Container/Implementation/GenericsAutoCloser.cs
@@ -84,7 +84,7 @@ namespace SimpleContainer.Implementation
 			if (cache.TryGetValue(definition, out types))
 				foreach (var type in types)
 					result.closures.Add(type);
-			else if (definition.IsAbstract)
+			else if (definition.IsAbstract())
 				MarkInterface(result, context);
 			else
 				MarkImplementation(result, context);
@@ -101,16 +101,16 @@ namespace SimpleContainer.Implementation
 			foreach (var parameter in parameters)
 			{
 				var parameterType = parameter.ParameterType;
-				if (parameterType.IsGenericType && (parameterType.GetGenericTypeDefinition() == typeof (IEnumerable<>)
-				                                    || parameterType.GetGenericTypeDefinition() == typeof (Func<>)))
+				if (parameterType.IsGenericType() && (parameterType.GetGenericTypeDefinition() == typeof (IEnumerable<>)
+				                                   || parameterType.GetGenericTypeDefinition() == typeof (Func<>)))
 					parameterType = parameterType.GetGenericArguments()[0];
 				if (parameterType.IsSimpleType())
 					continue;
-				if (!assemblyFilter(parameterType.Assembly.GetName()))
+				if (!assemblyFilter(parameterType.Assembly().GetName()))
 					continue;
-				if (!parameterType.IsGenericType)
+				if (!parameterType.IsGenericType())
 					continue;
-				if (!parameterType.ContainsGenericParameters)
+				if (!parameterType.ContainsGenericParameters())
 					continue;
 				if (parameterType.GenericParameters().Count != definition.type.GetGenericArguments().Length)
 					continue;
@@ -130,7 +130,7 @@ namespace SimpleContainer.Implementation
 			foreach (var implType in typesList.InheritorsOf(definition.type))
 			{
 				var interfaceImpls = implType.ImplementationsOf(definition.type);
-				if (implType.IsGenericType)
+				if (implType.IsGenericType())
 				{
 					var markedImpl = Mark(implType, context);
 					foreach (var interfaceImpl in interfaceImpls)
@@ -160,7 +160,7 @@ namespace SimpleContainer.Implementation
 			if (constraints.Length == 0)
 				return;
 			foreach (var c in constraints)
-				if (!assemblyFilter(c.Assembly.GetName()))
+				if (!assemblyFilter(c.Assembly().GetName()))
 					return;
 			var impls = typesList.InheritorsOf(constraints[0]);
 			for (var i = 1; i < constraints.Length; i++)
@@ -175,11 +175,11 @@ namespace SimpleContainer.Implementation
 			if (impls.Count == 0)
 				return;
 			var nonGenericOverrides = typesList.InheritorsOf(definition.type)
-				.Where(x => !x.IsGenericType)
+				.Where(x => !x.IsGenericType())
 				.ToArray();
 			foreach (var impl in impls)
 			{
-				if (genericArguments[0].GenericParameterAttributes.HasFlag(GenericParameterAttributes.DefaultConstructorConstraint))
+				if (genericArguments[0].GenericParameterAttributes().HasFlag(GenericParameterAttributes.DefaultConstructorConstraint))
 					if (impl.GetConstructor(Type.EmptyTypes) == null)
 						continue;
 				var closedItem = definition.type.MakeGenericType(impl);

--- a/_Src/Container/Implementation/LazyCreator.cs
+++ b/_Src/Container/Implementation/LazyCreator.cs
@@ -9,7 +9,7 @@ namespace SimpleContainer.Implementation
 	{
 		public static object TryCreate(ContainerService.Builder builder)
 		{
-			if (!builder.Type.IsGenericType)
+			if (!builder.Type.IsGenericType())
 				return null;
 			if (builder.Type.GetGenericTypeDefinition() != typeof (Lazy<>))
 				return null;

--- a/_Src/Container/Implementation/MemberInjectionsProvider.cs
+++ b/_Src/Container/Implementation/MemberInjectionsProvider.cs
@@ -39,7 +39,7 @@ namespace SimpleContainer.Implementation
 			MemberSetter[] baseSetters = null;
 			if (!type.IsDefined<FrameworkBoundaryAttribute>(false))
 			{
-				var baseType = type.BaseType;
+				var baseType = type.BaseType();
 				if (baseType != typeof (object))
 					baseSetters = GetMembers(baseType);
 			}

--- a/_Src/Container/Implementation/NestedFactoryCreator.cs
+++ b/_Src/Container/Implementation/NestedFactoryCreator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using SimpleContainer.Helpers;
 
 namespace SimpleContainer.Implementation
@@ -7,7 +8,7 @@ namespace SimpleContainer.Implementation
 	{
 		public static bool TryCreate(ContainerService.Builder builder)
 		{
-			var factoryType = builder.Type.GetNestedType("Factory");
+			var factoryType = builder.Type.GetNestedType("Factory", BindingFlags.Public);
 			if (factoryType == null)
 				return false;
 			var method = factoryType.GetMethod("Create", Type.EmptyTypes);

--- a/_Src/Container/Implementation/SimpleContainer.cs
+++ b/_Src/Container/Implementation/SimpleContainer.cs
@@ -135,7 +135,7 @@ namespace SimpleContainer.Implementation
 		private ServiceConfiguration GetConfigurationOrNull(Type type, ContractsList contracts)
 		{
 			var result = Configuration.GetConfigurationOrNull(type, contracts);
-			if (result == null && type.IsGenericType)
+			if (result == null && type.IsGenericType())
 				result = Configuration.GetConfigurationOrNull(type.GetDefinition(), contracts);
 			return result;
 		}
@@ -220,8 +220,8 @@ namespace SimpleContainer.Implementation
 			{
 				var message = string.Format("cyclic dependency for service [{0}], stack\r\n{1}",
 					declaredName.Type.FormatName(), context.FormatStack() + "\r\n\t" + declaredName);
-                context.Contracts.RemoveLast(pushedContracts.pushedContractsCount);
-                return ContainerService.Error(declaredName, message);
+				context.Contracts.RemoveLast(pushedContracts.pushedContractsCount);
+				return ContainerService.Error(declaredName, message);
 			}
 			if (!pushedContracts.isOk)
 			{
@@ -310,17 +310,17 @@ namespace SimpleContainer.Implementation
 				if (!builder.Context.AnalizeDependenciesOnly)
 					builder.CreateInstanceBy(CallTarget.F(builder.Configuration.Factory), builder.Configuration.ContainerOwnsInstance);
 			}
-			else if (builder.Type.IsValueType)
+			else if (builder.Type.IsValueType())
 				builder.SetError("can't create value type");
-			else if (builder.Type.IsGenericType && builder.Type.ContainsGenericParameters)
+			else if (builder.Type.IsGenericType() && builder.Type.ContainsGenericParameters())
 				builder.SetError("can't create open generic");
 			else if (!builder.CreateNew && builder.Type.TryGetCustomAttribute(out lifestyle) &&
-			         lifestyle.Lifestyle == Lifestyle.PerRequest)
+				lifestyle.Lifestyle == Lifestyle.PerRequest)
 			{
 				const string messageFormat = "service [{0}] with PerRequest lifestyle can't be resolved, use Func<{0}> instead";
 				builder.SetError(string.Format(messageFormat, builder.Type.FormatName()));
 			}
-			else if (builder.Type.IsAbstract)
+			else if (builder.Type.IsAbstract())
 				InstantiateInterface(builder);
 			else
 				InstantiateImplementation(builder);
@@ -350,17 +350,17 @@ namespace SimpleContainer.Implementation
 
 		private void InstantiateInterface(ContainerService.Builder builder)
 		{
-		    HashSet<ImplementationType> implementationTypes;
-		    try
-		    {
-		        implementationTypes = GetImplementationTypes(builder);
-		    }
-		    catch (Exception e)
-		    {
-		        builder.SetError(e);
-		        return;
-		    }
-		    ApplySelectors(implementationTypes, builder);
+			HashSet<ImplementationType> implementationTypes;
+			try
+			{
+				implementationTypes = GetImplementationTypes(builder);
+			}
+			catch (Exception e)
+			{
+				builder.SetError(e);
+				return;
+			}
+			ApplySelectors(implementationTypes, builder);
 			if (implementationTypes.Count == 0)
 			{
 				builder.SetComment("has no implementations");
@@ -416,12 +416,12 @@ namespace SimpleContainer.Implementation
 							accepted = false
 						});
 				}
-				if (!implType.IsGenericType)
+				if (!implType.IsGenericType())
 				{
-					if (!builder.Type.IsGenericType || builder.Type.IsAssignableFrom(implType))
+					if (!builder.Type.IsGenericType() || builder.Type.IsAssignableFrom(implType))
 						result.Add(ImplementationType.Accepted(implType));
 				}
-				else if (!implType.ContainsGenericParameters)
+				else if (!implType.ContainsGenericParameters())
 					result.Add(ImplementationType.Accepted(implType));
 				else
 				{
@@ -429,7 +429,7 @@ namespace SimpleContainer.Implementation
 					foreach (var type in mapped)
 						if (builder.Type.IsAssignableFrom(type))
 							result.Add(ImplementationType.Accepted(type));
-					if (builder.Type.IsGenericType)
+					if (builder.Type.IsGenericType())
 					{
 						var implInterfaces = implType.ImplementationsOf(builder.Type.GetGenericTypeDefinition());
 						foreach (var implInterface in implInterfaces)
@@ -446,7 +446,7 @@ namespace SimpleContainer.Implementation
 						continue;
 					foreach (var formalParameter in serviceConstructor.value.GetParameters())
 					{
-						if (!formalParameter.ParameterType.ContainsGenericParameters)
+						if (!formalParameter.ParameterType.ContainsGenericParameters())
 							continue;
 						ValueWithType parameterValue;
 						if (!builder.Arguments.TryGet(formalParameter.Name, out parameterValue))
@@ -472,7 +472,7 @@ namespace SimpleContainer.Implementation
 			EnsureNotDisposed();
 			if (type.IsDelegate())
 				return Enumerable.Empty<Type>();
-			if (!type.IsAbstract)
+			if (!type.IsAbstract())
 			{
 				var result = dependenciesInjector.GetDependencies(type)
 					.Select(ReflectionHelpers.UnwrapEnumerable)
@@ -649,11 +649,11 @@ namespace SimpleContainer.Implementation
 			FromResourceAttribute resourceAttribute;
 			if (implementationType == typeof (Stream) && formalParameter.TryGetCustomAttribute(out resourceAttribute))
 			{
-				var resourceStream = builder.Type.Assembly.GetManifestResourceStream(builder.Type, resourceAttribute.Name);
+				var resourceStream = builder.Type.Assembly().GetManifestResourceStream(builder.Type.Namespace + "." + resourceAttribute.Name);
 				if (resourceStream == null)
 					return containerContext.Error(null, formalParameter.Name,
 						"can't find resource [{0}] in namespace of [{1}], assembly [{2}]",
-						resourceAttribute.Name, builder.Type, builder.Type.Assembly.GetName().Name);
+						resourceAttribute.Name, builder.Type, builder.Type.Assembly().GetName().Name);
 				return containerContext.Resource(formalParameter, resourceAttribute.Name, resourceStream);
 			}
 			var dependencyName = ServiceName.Parse(implementationType.UnwrapEnumerable(),

--- a/_Src/Container/Implementation/TypesList.cs
+++ b/_Src/Container/Implementation/TypesList.cs
@@ -25,7 +25,7 @@ namespace SimpleContainer.Implementation
 
 		public IEnumerable<Assembly> GetAssemblies()
 		{
-			return Types.Select(x => x.Assembly).Distinct().ToArray();
+			return Types.Select(x => x.Assembly()).Distinct().ToArray();
 		}
 
 		public static TypesList Create(Type[] types)
@@ -33,9 +33,9 @@ namespace SimpleContainer.Implementation
 			var result = new Dictionary<Type, List<Type>>();
 			foreach (var type in types)
 			{
-				if (type.IsAbstract)
+				if (type.IsAbstract())
 					continue;
-				if (type.IsNestedPrivate)
+				if (type.IsNestedPrivate())
 					continue;
 				var t = type.GetDefinition();
 				foreach (var interfaceType in t.GetInterfaces())
@@ -44,7 +44,7 @@ namespace SimpleContainer.Implementation
 				while (current != null && current != typeof (object))
 				{
 					Include(result, current.GetDefinition(), t);
-					current = current.BaseType;
+					current = current.BaseType();
 				}
 			}
 			return new TypesList(types, result);

--- a/_Src/Container/Interface/ServiceName.cs
+++ b/_Src/Container/Interface/ServiceName.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using SimpleContainer.Helpers;
 
 namespace SimpleContainer.Interface
@@ -17,7 +18,7 @@ namespace SimpleContainer.Interface
 		internal static ServiceName Parse(Type type, string[] contracts)
 		{
 			var typeContracts = InternalHelpers.ParseContracts(type);
-			return new ServiceName(type, contracts.Concat(typeContracts));
+			return new ServiceName(type, contracts.Concat(typeContracts).ToArray());
 		}
 
 		public Type Type

--- a/_Src/Container/Interface/SimpleContainerException.cs
+++ b/_Src/Container/Interface/SimpleContainerException.cs
@@ -1,9 +1,10 @@
 using System;
-using System.Runtime.Serialization;
 
 namespace SimpleContainer.Interface
 {
-	[Serializable]
+#if !NETCORE1
+	[System.Runtime.Serialization.Serializable]
+#endif
 	public class SimpleContainerException : Exception
 	{
 		public SimpleContainerException(string message)
@@ -15,8 +16,10 @@ namespace SimpleContainer.Interface
 		{
 		}
 
+#if !NETCORE1
 		protected SimpleContainerException(SerializationInfo info, StreamingContext context) : base(info, context)
 		{
 		}
+#endif
 	}
 }

--- a/_Src/Container/Portability/AppDomain.cs
+++ b/_Src/Container/Portability/AppDomain.cs
@@ -1,0 +1,28 @@
+#if NETCORE1
+
+namespace System
+{
+    public class AppDomain
+    {
+        static Lazy<AppDomain> _currentDomain = new Lazy<AppDomain>(() => new AppDomain());
+        public static AppDomain CurrentDomain
+        {
+            get { return _currentDomain.Value; }
+        }
+
+        public string BaseDirectory
+        {
+            get
+            {
+                return AppContext.BaseDirectory;
+            }
+        }
+
+        public string RelativeSearchPath
+        {
+            get { return null; }
+        }
+    }
+}
+
+#endif

--- a/_Src/Container/Portability/Portability.cs
+++ b/_Src/Container/Portability/Portability.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace SimpleContainer
+{
+    public static class Portability
+    {
+        public static AssemblyName GetAssemblyName(string file)
+        {
+#if NETCORE1
+            return System.Runtime.Loader.AssemblyLoadContext.GetAssemblyName(file);
+#else
+            return AssemblyName.GetAssemblyName(file);
+#endif
+        }
+
+        public static Assembly GetSimpleContainerAssembly()
+        {
+#if NETCORE1
+            return typeof(Portability).GetTypeInfo().Assembly;
+#else
+            return Assembly.GetExecutingAssembly();
+#endif
+        }
+    }
+}

--- a/_Src/Container/Portability/TypeExtensions.cs
+++ b/_Src/Container/Portability/TypeExtensions.cs
@@ -1,0 +1,251 @@
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace System
+{
+	public static class TypeExtensions
+	{
+
+#if NETCORE1
+
+		public static Assembly Assembly(this Type t)
+		{
+			return t.GetTypeInfo().Assembly;
+		}
+
+		public static Type BaseType(this Type t)
+		{
+			return t.GetTypeInfo().BaseType;
+		}
+
+		public static bool ContainsGenericParameters(this Type t)
+		{
+			return t.GetTypeInfo().ContainsGenericParameters;
+		}
+
+		public static bool IsAbstract(this Type t)
+		{
+			return t.GetTypeInfo().IsAbstract;
+		}
+
+		public static bool IsAssignableFrom(this Type t, Type fromT)
+		{
+			return t.GetTypeInfo().IsAssignableFrom(fromT);
+		}
+
+		public static bool IsDefined(this Type t, Type defType, bool inherit)
+		{
+			return t.GetTypeInfo().IsDefined(defType, inherit);
+		}
+
+		public static bool IsGenericType(this Type t)
+		{
+			return t.GetTypeInfo().IsGenericType;
+		}
+
+		public static bool IsInterface(this Type t)
+		{
+			return t.GetTypeInfo().IsInterface;
+		}
+
+		public static bool IsEnum(this Type t)
+		{
+			return t.GetTypeInfo().IsEnum;
+		}
+
+		public static bool IsGenericTypeDefinition(this Type t)
+		{
+			return t.GetTypeInfo().IsGenericTypeDefinition;
+		}
+
+		public static GenericParameterAttributes GenericParameterAttributes(this Type t)
+		{
+			return t.GetTypeInfo().GenericParameterAttributes;
+		}
+
+		public static bool IsNestedPublic(this Type t)
+		{
+			return t.GetTypeInfo().IsNestedPublic;
+		}
+
+		public static bool IsNestedPrivate(this Type t)
+		{
+			return t.GetTypeInfo().IsNestedPrivate;
+		}
+
+		public static bool IsValueType(this Type t)
+		{
+			return t.GetTypeInfo().IsValueType;
+		}
+
+		public static bool IsInstanceOfType(this Type t, object fromT)
+		{
+			return t.GetTypeInfo().IsInstanceOfType(fromT);
+		}
+
+		public static ConstructorInfo[] GetConstructors(this Type t)
+		{
+			return t.GetTypeInfo().GetConstructors();
+		}
+
+		public static ConstructorInfo[] GetConstructors(this Type t, BindingFlags flags)
+		{
+			return t.GetTypeInfo().GetConstructors(flags);
+		}
+
+		public static ConstructorInfo GetConstructor(this Type t, Type[] parametersTypes)
+		{
+			return t.GetTypeInfo().GetConstructor(parametersTypes);
+		}
+
+		public static MethodInfo[] GetMethods(this Type t)
+		{
+			return t.GetTypeInfo().GetMethods();
+		}
+
+		public static MethodInfo[] GetMethods(this Type t, BindingFlags flags)
+		{
+			return t.GetTypeInfo().GetMethods(flags);
+		}
+
+		public static MethodInfo GetMethod(this Type t, string methodName)
+		{
+			return t.GetTypeInfo().GetMethod(methodName);
+		}
+
+		public static MethodInfo GetMethod(this Type t, string methodName, BindingFlags flags)
+		{
+			return t.GetTypeInfo().GetMethod(methodName, flags);
+		}
+
+		public static MethodInfo GetMethod(this Type t, string methodName, Type[] parametersTypes)
+		{
+			return t.GetTypeInfo().GetMethod(methodName, parametersTypes);
+		}
+
+		public static Type[] GetInterfaces(this Type t)
+		{
+			return t.GetTypeInfo().GetInterfaces();
+		}
+
+		public static PropertyInfo[] GetProperties(this Type t)
+		{
+			return t.GetTypeInfo().GetProperties();
+		}
+
+		public static PropertyInfo[] GetProperties(this Type t, BindingFlags flags)
+		{
+			return t.GetTypeInfo().GetProperties(flags);
+		}
+
+		public static PropertyInfo GetProperty(this Type t, string propertyName)
+		{
+			return t.GetTypeInfo().GetProperty(propertyName);
+		}
+
+		public static FieldInfo[] GetFields(this Type t)
+		{
+			return t.GetTypeInfo().GetFields();
+		}
+
+		public static FieldInfo[] GetFields(this Type t, BindingFlags flags)
+		{
+			return t.GetTypeInfo().GetFields(flags);
+		}
+
+		public static IEnumerable<Attribute> GetCustomAttributes(this Type t, bool inherit)
+		{
+			return t.GetTypeInfo().GetCustomAttributes(inherit);
+		}
+
+		public static IEnumerable<Attribute> GetCustomAttributes(this Type t, Type attributeType, bool inherit)
+		{
+			return t.GetTypeInfo().GetCustomAttributes(attributeType, inherit);
+		}
+
+		public static Type[] GetGenericArguments(this Type t)
+		{
+			return t.GetTypeInfo().GetGenericArguments();
+		}
+
+		public static Type[] GetGenericParameterConstraints(this Type t)
+		{
+			return t.GetTypeInfo().GetGenericParameterConstraints();
+		}
+
+		public static Type GetGenericTypeDefinition(this Type t)
+		{
+			return t.GetTypeInfo().GetGenericTypeDefinition();
+		}
+
+		public static Type GetNestedType(this Type t, string name, BindingFlags flags)
+		{
+			return t.GetTypeInfo().GetNestedType(name, flags);
+		}
+
+#else
+
+		public static Assembly Assembly(this Type t)
+		{
+			return t.Assembly;
+		}
+
+		public static Type BaseType(this Type t)
+		{
+			return t.BaseType;
+		}
+
+		public static bool ContainsGenericParameters(this Type t)
+		{
+			return t.ContainsGenericParameters;
+		}
+
+		// public static bool IsArray(this Type t)
+		// {
+		//     return t.IsArray;
+		// }
+
+		public static bool IsAbstract(this Type t)
+		{
+			return t.IsAbstract;
+		}
+
+		public static bool IsGenericType(this Type t)
+		{
+			return t.IsGenericType;
+		}
+
+		public static bool IsInterface(this Type t)
+		{
+			return t.IsInterface;
+		}
+
+		public static bool IsEnum(this Type t)
+		{
+			return t.IsEnum;
+		}
+
+		public static bool IsGenericTypeDefinition(this Type t)
+		{
+			return t.IsGenericTypeDefinition;
+		}
+
+		public static bool IsNestedPublic(this Type t)
+		{
+			return t.IsNestedPublic;
+		}
+
+		public static bool IsNestedPrivate(this Type t)
+		{
+			return t.IsNestedPrivate;
+		}
+
+		public static bool IsValueType(this Type t)
+		{
+			return t.IsValueType;
+		}
+
+
+#endif
+	}
+}

--- a/_Src/Container/project.json
+++ b/_Src/Container/project.json
@@ -1,0 +1,42 @@
+{
+  "version": "1.0.0-*",
+  "dependencies": {
+    "NETStandard.Library": "1.6.0"
+  },
+  "frameworks": {
+    "netstandard1.6": {
+      "imports": "dnxcore50",
+      "buildOptions": {
+        "define": [
+          "NETCORE1"
+        ]
+      },
+      "dependencies": {
+        "System.Reflection": {
+          "type": "build",
+          "version": "4.1.0"
+        },
+        "System.Runtime.Extensions": {
+          "type": "build",
+          "version": "4.1.0"
+        },
+        "System.Reflection.Emit.ILGeneration": {
+          "type": "build",
+          "version": "4.0.1"
+        },
+        "System.Reflection.Emit.Lightweight": {
+          "type": "build",
+          "version": "4.0.1"
+        },
+        "System.Runtime.Loader": {
+          "type": "build",
+          "version": "4.0.0"
+        },
+        "System.Linq.Parallel": {
+          "type": "build",
+          "version": "4.0.1"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Please, review this PR.
It provides the way to compile simple-container under [.NET Core](https://www.microsoft.com/net/core/platform).

For trying, you can go to _Src/Container folder, and run commands:

```
 dotnet restore
 dotnet build
```

The main challenge with .NET Core is broken backward compatibility. It has no AppDomain at all for now. Also, the Type class has been cutted and all properties has been moved to TypeInfo class (which now implements ICustomAttributeProvider interface). TypeInfo class instance can be retrieved from Type by extension method Type.GetTypeInfo().

What do you think about this kind of portability layer?
